### PR TITLE
Language changes to lead paragraph and metadata

### DIFF
--- a/content/site/de/config.yml
+++ b/content/site/de/config.yml
@@ -1,10 +1,10 @@
 language: "de"
-questionnaire_language: "en"
+questionnaire_language: "de"
 title: "RETTE DAS INTERNET IN EUROPA"
 action: "Mach mit und tu etwas! Sende eine Nachricht an die Regulierer:"
 keywords:
   - net neutrality
-  - connected conntinent
+  - connected continent
   - digital single market
   - dsm
   - neelie kroes

--- a/content/site/de/index.md
+++ b/content/site/de/index.md
@@ -10,9 +10,7 @@
 # Save the Internet
 
 {: .title-subtext}
-Europäische Regulierungsbehörden werden demnächst entscheiden, ob man großen Telekomfirmen das Recht geben soll
-Einfluss darauf zu nehmen was wir online tun (und nicht tun) können. Europa braucht dringend klare Netzneutralitätsregeln
-um unsere Freiheit und Rechte online zu bewahren. Wir haben Zeit bis __Juli__ um Europa zu helfen das freie Internet zu schützen.
+Europäische Regulierungsbehörden werden in Kürze entscheiden, ob große Telekommunikationsfirmen beeinflussen dürfen, was wir online tun (und nicht tun) können. Europa braucht dringend klare Regeln für Netzneutralität, um unsere Freiheiten und Rechte online zu schützen. Wir haben Zeit bis __Juli__, um Europa bei der Bewahrung des freien Internets zu helfen.
 <br><br>
 Schließe dich uns an, hilf jetzt mit!
 


### PR DESCRIPTION
The German lead paragraph was missing some commas – and I think it also needed some improvements to the language. Also fixed a typo in the metadata. Please review the change I made to the metadata item called “questionnaire_language”. Will it mean that the IFrame now links to the German version of the questionnaire, for which the URL https://consultation.savetheinternet.eu/german/ has now been created and whose German content is being prepared?