### PR TITLE
Fix counter spacing

### DIFF
--- a/stylesheets/site/_home.scss
+++ b/stylesheets/site/_home.scss
@@ -93,6 +93,7 @@
       margin-right: auto;
       width: available;
       visibility: hidden;
+      margin-bottom: 1em;
       tr {
         td:nth-child(odd) {
           @include setFontToBaseline(32px, 1, 1);


### PR DESCRIPTION
If the text next to the counter values is longer than usual (e.g. German translation), the spacing between the counter and the button below gets too low which does look somewhat broken to me.
Adding a bottom margin to the table containing the counter values and text solves this issue despite pushing the header a bit down.

Screenshot of the issue:
![sti-ui-german-counter](https://cloud.githubusercontent.com/assets/343302/16366007/00a76a3c-3c10-11e6-80f9-c54f03fa49dd.png)
Screenshot of fix:
![sti-ui-german-counter-margin-bottom](https://cloud.githubusercontent.com/assets/343302/16366006/00a19896-3c10-11e6-835a-6fbc4e044111.png)