### PR TITLE
Fix long navigation items overlapping the top logo

### DIFF
--- a/stylesheets/site/_home.scss
+++ b/stylesheets/site/_home.scss
@@ -3,13 +3,15 @@
   background-repeat: no-repeat;
   background-size: 161px;
   min-height: 86px;
-
   padding-top: 30px;
+  padding-left: 161px;
+  text-align: left;
 
   ul {
     display: inline;
     list-style-type: none;
     margin-top: 0px;
+	padding: 0px;
     li {
       display: inline;
       a {
@@ -23,7 +25,7 @@
   .navigation__sections {
     text-align: center;
     li {
-      padding-right: 50px;
+      padding-right: 30px;
       a {
         letter-spacing: 0.14em;
       }


### PR DESCRIPTION
If the navigation items contain long text (e.g. German, Italian,
Romanian versions) the navigation items sometimes overlap the logo at
the top of the site. This makes the site look somewhat broken. The
cause of this issue is mainly due to the centering of the text. This is
fixed by aligning the text to the left and adding a padding which
corresponds the width of the logo (161px). Additionally the beginning
padding of ul elements is removed and the spacing between the
navigation items are reduced to use the space more efficiently.

Before (German version):
![sti-ui-german-navigation](https://cloud.githubusercontent.com/assets/343302/16366346/7de1023c-3c16-11e6-8f48-b1207e6135cb.png)
After (German version):
![sti-ui-german-navigation-fixed](https://cloud.githubusercontent.com/assets/343302/16366348/8964fa3c-3c16-11e6-8198-8539e7c4198b.png)
Before (Romanian version):
![sti-ui-romanian-navigation](https://cloud.githubusercontent.com/assets/343302/16366352/9821aeda-3c16-11e6-9f5c-57840f7066cb.png)
After (Romanian version):
![sti-ui-romanian-navigation-fixed](https://cloud.githubusercontent.com/assets/343302/16366355/9e1c6bb8-3c16-11e6-9a50-5f565d8030ad.png)