### PR TITLE
Adds a logo cloud of companies that signed the net neutrality letter

### DIFF
--- a/content/en/index.md
+++ b/content/en/index.md
@@ -121,6 +121,15 @@ Regulators need to equip themselves with the tools to enforce net neutrality. In
 ## BEREC [needs your input](#send-a-message){: data-scroll="true"} before they decide on the future of net neutrality in Europe.
 {{ END HOME BEREC-5 }}
 
+{{ BEGIN HOME COALITION }}
+### Together, we support strong Net Neutrality rules.
+
+These founders and investors have signed on to the [entrepreneur letter for net neutrality](http://www.factory.co/net-neutrality) in Europe, asking BEREC for strong, clear guidelines without loopholes.
+
+<script type="text/javascript" id="fftf_logo_cloud" src="https://www.savenetneutrality.eu/js/logos.js"></script>
+
+{{ END HOME COALITION }}
+
 {{ BEGIN HOME CONTACT-US }}
 ### Contact Us
 

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -126,7 +126,7 @@ Regulators need to equip themselves with the tools to enforce net neutrality. In
 
 These founders and investors have signed on to the [entrepreneur letter for net neutrality](http://www.factory.co/net-neutrality) in Europe, asking BEREC for strong, clear guidelines without loopholes.
 
-<script type="text/javascript" id="fftf_logo_cloud" src="https://www.savenetneutrality.eu/js/logos.js"></script>
+<script type="text/javascript" id="fftf_logo_cloud" integrity="sha384-c5XDgk1De7w/Rb+Ay2D61EGhmJS/HlsD0+pbhOW+8fQ53Q6xnxr/AFezmu6HuoD0" crossorigin="anonymous" src="https://www.savenetneutrality.eu/js/logos.js"></script>
 
 {{ END HOME COALITION }}
 

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -126,7 +126,7 @@ Regulators need to equip themselves with the tools to enforce net neutrality. In
 
 These founders and investors have signed on to the [entrepreneur letter for net neutrality](http://www.factory.co/net-neutrality) in Europe, asking BEREC for strong, clear guidelines without loopholes.
 
-<script type="text/javascript" id="fftf_logo_cloud" integrity="sha384-c5XDgk1De7w/Rb+Ay2D61EGhmJS/HlsD0+pbhOW+8fQ53Q6xnxr/AFezmu6HuoD0" crossorigin="anonymous" src="https://www.savenetneutrality.eu/js/logos.js"></script>
+<script type="text/javascript" id="fftf_logo_cloud" integrity="sha384-QrA+/FdpeCpLWf/GekgzUU/uayMqrjQeKoQRIT4aZNfQvqr6oJUeAhKcShRSEv81" crossorigin="anonymous" src="https://www.savenetneutrality.eu/js/logos.js"></script>
 
 {{ END HOME COALITION }}
 

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -126,7 +126,7 @@ Regulators need to equip themselves with the tools to enforce net neutrality. In
 
 These founders and investors have signed on to the [entrepreneur letter for net neutrality](http://www.factory.co/net-neutrality) in Europe, asking BEREC for strong, clear guidelines without loopholes.
 
-<script type="text/javascript" id="fftf_logo_cloud" integrity="sha384-QrA+/FdpeCpLWf/GekgzUU/uayMqrjQeKoQRIT4aZNfQvqr6oJUeAhKcShRSEv81" crossorigin="anonymous" src="https://www.savenetneutrality.eu/js/logos.js"></script>
+<script type="text/javascript" id="fftf_logo_cloud" integrity="sha384-rY9HgqO1qTdzfKDplrb4HEG65jVrF8JT8iG4Gv7wAjynddlhdn64sKxjO71/oqmH" crossorigin="anonymous" src="https://www.savenetneutrality.eu/js/logos.js"></script>
 
 {{ END HOME COALITION }}
 

--- a/stylesheets/site/_home.scss
+++ b/stylesheets/site/_home.scss
@@ -526,6 +526,18 @@
   }
 }
 
+.home__coalition__outer {
+
+}
+.home__coalition__inner {
+  @include container;
+
+}
+.home__coalition__content {
+  @include span(24);
+  color: $sti-blue-light-new;
+}
+
 .home__contact-us__outer {
 
 }


### PR DESCRIPTION
This adds a logo cloud to the homepage using a Javascript widget hosted by savenetneutrality.eu. You won't have to worry about adding logos because they're pulled in dynamically using JavaScript.

The remote script include uses a subresource integrity hash to prevent man-in-the-middle attacks (or savenetneutrality.eu being compromised and putting malicious scripts on your site). This prevents us from changing the script, but we won't have to, because it's super simple. It just embeds an iframe on the page and resizes it to fit the logos contained inside. (See the code [here](https://github.com/fightforthefuture/eunetneutrality/blob/master/app/js/logos.js))

See attached screenshot.
![screenshot from 2016-07-12 16-42-10](https://cloud.githubusercontent.com/assets/3049100/16784924/d326d5b4-4850-11e6-9aae-7a41c0bc0ac1.png)
